### PR TITLE
The SignalR hub tests now implement different semantics. You can use …

### DIFF
--- a/server/tests/Cafe.Tests/Api/Hubs/ConfirmedOrdersHubTests.cs
+++ b/server/tests/Cafe.Tests/Api/Hubs/ConfirmedOrdersHubTests.cs
@@ -44,8 +44,8 @@ namespace Cafe.Tests.Api.Hubs
             await _toGoOrdersHelper.CreateConfirmedOrder(orderId, menuItems);
 
             // Assert
-            testConnection
-                .VerifyMessageReceived(
+            await testConnection
+                .VerifyMessageReceived<OrderConfirmed>(
                     e => e.Order.Id == orderId &&
                          e.Order.OrderedItems.Count == menuItems.Length,
                     Times.Once());
@@ -95,8 +95,8 @@ namespace Cafe.Tests.Api.Hubs
             await _toGoOrdersHelper.CreateConfirmedOrder(orderId, menuItems);
 
             // Assert
-            testConnection
-                .VerifyMessageReceived(
+            await testConnection
+                .VerifyMessageReceived<OrderConfirmed>(
                     e => e.Order.Id == orderId &&
                          e.Order.OrderedItems.Count == menuItems.Length,
                     Times.Once());
@@ -119,10 +119,10 @@ namespace Cafe.Tests.Api.Hubs
             exception.Message.ShouldContain("401");
         }
 
-        private TestHubConnection<OrderConfirmed> BuildTestConnection(string accessToken) =>
-            new TestHubConnectionBuilder<OrderConfirmed>()
-                .WithHub(_hubUrl)
-                .WithExpectedMessage(nameof(OrderConfirmed))
+        private TestHubConnection BuildTestConnection(string accessToken) =>
+            new TestHubConnectionBuilder()
+                .OnHub(_hubUrl)
+                .WithExpectedEvent<OrderConfirmed>(nameof(OrderConfirmed))
                 .WithAccessToken(accessToken)
                 .Build();
     }

--- a/server/tests/Cafe.Tests/Api/Hubs/HiredWaitersHubTests.cs
+++ b/server/tests/Cafe.Tests/Api/Hubs/HiredWaitersHubTests.cs
@@ -40,8 +40,8 @@ namespace Cafe.Tests.Api.Hubs
             await _fixture.SendAsync(hireWaiterCommand);
 
             // Assert
-            testConnection
-                .VerifyMessageReceived(
+            await testConnection
+                .VerifyMessageReceived<WaiterHired>(
                     e => e.Waiter.Id == hireWaiterCommand.Id &&
                          e.Waiter.ShortName == hireWaiterCommand.ShortName,
                     Times.Once());
@@ -90,8 +90,8 @@ namespace Cafe.Tests.Api.Hubs
             await _fixture.SendAsync(hireWaiterCommand);
 
             // Assert
-            testConnection
-                .VerifyMessageReceived(
+            await testConnection
+                .VerifyMessageReceived<WaiterHired>(
                     e => e.Waiter.Id == hireWaiterCommand.Id &&
                          e.Waiter.ShortName == hireWaiterCommand.ShortName,
                     Times.Once());
@@ -113,10 +113,10 @@ namespace Cafe.Tests.Api.Hubs
             exception.Message.ShouldContain("401");
         }
 
-        private TestHubConnection<WaiterHired> BuildTestConnection(string accessToken) =>
-            new TestHubConnectionBuilder<WaiterHired>()
-                .WithHub(_hubUrl)
-                .WithExpectedMessage(nameof(WaiterHired))
+        private TestHubConnection BuildTestConnection(string accessToken) =>
+            new TestHubConnectionBuilder()
+                .OnHub(_hubUrl)
+                .WithExpectedEvent<WaiterHired>(nameof(WaiterHired))
                 .WithAccessToken(accessToken)
                 .Build();
     }

--- a/server/tests/Cafe.Tests/Api/Hubs/TableActionsHubTests.cs
+++ b/server/tests/Cafe.Tests/Api/Hubs/TableActionsHubTests.cs
@@ -45,7 +45,7 @@ namespace Cafe.Tests.Api.Hubs
             await _fixture.SendAsync(callWaiterCommand);
 
             // Assert
-            testConnection.VerifyMessageReceived(
+            await testConnection.VerifyMessageReceived<WaiterCalled>(
                 e => e.TableNumber == addTableCommand.Number &&
                      e.WaiterId == hireWaiterCommand.Id,
                 Times.Once());
@@ -72,7 +72,7 @@ namespace Cafe.Tests.Api.Hubs
             await _fixture.SendAsync(requestBillCommand);
 
             // Assert
-            testConnection.VerifyMessageReceived(
+            await testConnection.VerifyMessageReceived<BillRequested>(
                 e => e.TableNumber == addTableCommand.Number &&
                      e.WaiterId == hireWaiterCommand.Id,
                 Times.Once());
@@ -104,7 +104,7 @@ namespace Cafe.Tests.Api.Hubs
             await _fixture.SendAsync(requestBillCommand);
 
             // Assert
-            testConnection.VerifyNoMessagesWereReceived();
+            await testConnection.VerifyNoMessagesWereReceived();
         }
 
         [Theory]
@@ -133,7 +133,7 @@ namespace Cafe.Tests.Api.Hubs
             await _fixture.SendAsync(callWaiterCommand);
 
             // Assert
-            testConnection.VerifyNoMessagesWereReceived();
+            await testConnection.VerifyNoMessagesWereReceived();
         }
 
         [Theory]
@@ -169,9 +169,9 @@ namespace Cafe.Tests.Api.Hubs
             await _fixture.SendAsync(callWaiterCommand);
 
             // Assert
-            invalidTestConnection.VerifyNoMessagesWereReceived();
+            await invalidTestConnection.VerifyNoMessagesWereReceived();
 
-            validTestConnection.VerifyMessageReceived(
+            await validTestConnection.VerifyMessageReceived<WaiterCalled>(
                 e => e.TableNumber == addTableCommand.Number &&
                      e.WaiterId == hireAssignedWaiterCommand.Id,
                 Times.Once());
@@ -210,15 +210,15 @@ namespace Cafe.Tests.Api.Hubs
             await _fixture.SendAsync(requestBillCommand);
 
             // Assert
-            invalidTestConnection.VerifyNoMessagesWereReceived();
+            await invalidTestConnection.VerifyNoMessagesWereReceived();
 
-            validTestConnection.VerifyMessageReceived(
+            await validTestConnection.VerifyMessageReceived<BillRequested>(
                 e => e.TableNumber == addTableCommand.Number &&
                      e.WaiterId == hireAssignedWaiterCommand.Id,
                 Times.Once());
         }
 
-        private async Task<TestHubConnection<TEvent>> BuildTestHubConnectionWithoutAssignedWaiter<TEvent>(
+        private async Task<TestHubConnection> BuildTestHubConnectionWithoutAssignedWaiter<TEvent>(
             HireWaiter hireAssignedWaiterCommand,
             HireWaiter hireUnassignedWaiterCommand,
             AddTable addTableCommand,
@@ -248,7 +248,7 @@ namespace Cafe.Tests.Api.Hubs
             return testConnection;
         }
 
-        private async Task<TestHubConnection<TEvent>> BuildTestTableActionConnection<TEvent>(HireWaiter hireWaiterCommand, AddTable addTableCommand, Register registerCommand)
+        private async Task<TestHubConnection> BuildTestTableActionConnection<TEvent>(HireWaiter hireWaiterCommand, AddTable addTableCommand, Register registerCommand)
         {
             await HireWaiterWithTable(hireWaiterCommand, addTableCommand);
 
@@ -283,10 +283,10 @@ namespace Cafe.Tests.Api.Hubs
             await _fixture.SendAsync(assignTableCommand);
         }
 
-        private TestHubConnection<TEvent> BuildTestConnection<TEvent>(string accessToken) =>
-            new TestHubConnectionBuilder<TEvent>()
-                .WithHub(_hubUrl)
-                .WithExpectedMessage(typeof(TEvent).Name)
+        private TestHubConnection BuildTestConnection<TEvent>(string accessToken) =>
+            new TestHubConnectionBuilder()
+                .OnHub(_hubUrl)
+                .WithExpectedEvent<TEvent>(typeof(TEvent).Name)
                 .WithAccessToken(accessToken)
                 .Build();
     }

--- a/server/tests/Cafe.Tests/Extensions/MoqExtensions.cs
+++ b/server/tests/Cafe.Tests/Extensions/MoqExtensions.cs
@@ -2,7 +2,7 @@
 using System;
 using System.Diagnostics;
 using System.Linq.Expressions;
-using System.Threading;
+using System.Threading.Tasks;
 
 namespace Cafe.Tests.Extensions
 {
@@ -16,7 +16,7 @@ namespace Cafe.Tests.Extensions
         /// <param name="expression">Verification expression.</param>
         /// <param name="times">Times the method should have been called.</param>
         /// <param name="timeoutInMs">Timeout in milliseconds.</param>
-        public static void VerifyWithTimeout<T>(this Mock<T> mock, Expression<Action<T>> expression, Times times, int timeoutInMs)
+        public static async Task VerifyWithTimeoutAsync<T>(this Mock<T> mock, Expression<Action<T>> expression, Times times, int timeoutInMs)
             where T : class
         {
             bool hasBeenExecuted = false;
@@ -37,11 +37,14 @@ namespace Cafe.Tests.Extensions
                     mock.Verify(expression, times);
                     hasBeenExecuted = true;
                 }
+#pragma warning disable RCS1075 // Avoid empty catch clause that catches System.Exception.
                 catch (Exception)
+#pragma warning restore RCS1075 // Avoid empty catch clause that catches System.Exception.
                 {
                 }
 
-                Thread.Sleep(20);
+                // Feel free to make this configurable
+                await Task.Delay(20);
             }
 
             mock.Verify(expression, times);

--- a/server/tests/Cafe.Tests/HandlerNotRegisteredException.cs
+++ b/server/tests/Cafe.Tests/HandlerNotRegisteredException.cs
@@ -1,0 +1,13 @@
+﻿using System;
+
+namespace Cafe.Tests
+{
+    public class HandlerNotRegisteredException : Exception
+    {
+        public HandlerNotRegisteredException(Type eventType)
+            : base($"Tried to verify that event of type {eventType.FullName} was received before registering it as expected. " +
+                  $"Please use the {nameof(TestHubConnection.Expect)} method to register an event as expected before verifying it was called.")
+        {
+        }
+    }
+}

--- a/server/tests/Cafe.Tests/TestHubConnection.cs
+++ b/server/tests/Cafe.Tests/TestHubConnection.cs
@@ -2,46 +2,115 @@
 using Microsoft.AspNetCore.SignalR.Client;
 using Moq;
 using System;
+using System.Collections.Generic;
+using System.Linq;
 using System.Linq.Expressions;
+using System.Reflection;
 using System.Threading.Tasks;
 
 namespace Cafe.Tests
 {
-    public class TestHubConnection<TEvent>
+    public class TestHubConnection
     {
         private readonly HubConnection _connection;
-        private readonly string _expectedEventToReceive;
-        private readonly Mock<Action<TEvent>> _handlerMock;
+        private readonly Dictionary<Type, object> _handlersMap;
         private readonly int _verificationTimeout;
 
-        internal TestHubConnection(HubConnection connection, string expectedEventToReceive, int verificationTimeout = 10000)
+        internal TestHubConnection(string url, string accessToken, int verificationTimeout = 10000)
         {
-            if (connection.State == HubConnectionState.Connected)
-            {
-                throw new ArgumentException($"You shouldn't pass open connections. Use {nameof(OpenAsync)}" +
-                    $"to open the connection before verifying that the message was received.");
-            }
+            _connection = new HubConnectionBuilder()
+                .WithUrl(url, opts =>
+                {
+                    opts.AccessTokenProvider = () => Task.FromResult(accessToken);
+                })
+                .Build();
 
-            _handlerMock = new Mock<Action<TEvent>>();
-            _expectedEventToReceive = expectedEventToReceive;
-            _connection = connection;
             _verificationTimeout = verificationTimeout;
+            _handlersMap = new Dictionary<Type, object>();
+        }
+
+        public void Expect<TEvent>(string expectedName)
+        {
+            var handlerMock = new Mock<Action<TEvent>>();
+            RegisterHandler(handlerMock);
+            _connection.On(expectedName, handlerMock.Object);
+        }
+
+        public void Expect(string expectedName, Type expectedType)
+        {
+            var genericExpectMethod = GetGenericMethod(
+                nameof(Expect),
+                new[] { expectedType });
+
+            genericExpectMethod.Invoke(this, new[] { expectedName });
         }
 
         public async Task OpenAsync()
         {
             await _connection.StartAsync();
-            _connection.On(_expectedEventToReceive, _handlerMock.Object);
         }
 
-        public void VerifyMessageReceived(Expression<Func<TEvent, bool>> predicate, Times times)
+        public async Task VerifyMessageReceived<TEvent>(Expression<Func<TEvent, bool>> predicate, Times times)
         {
-            _handlerMock.VerifyWithTimeout(x => x(It.Is<TEvent>(predicate)), times, _verificationTimeout);
+            if (!_handlersMap.ContainsKey(typeof(TEvent)))
+                throw new HandlerNotRegisteredException(typeof(TEvent));
+
+            var handlersForType = _handlersMap[typeof(TEvent)];
+
+            foreach (var handler in (List<Mock<Action<TEvent>>>)handlersForType)
+            {
+                await handler.VerifyWithTimeoutAsync(
+                    x => x(It.Is(predicate)),
+                    times,
+                    _verificationTimeout);
+            }
         }
 
-        public void VerifyNoMessagesWereReceived()
+        public async Task VerifyNoMessagesWereReceived()
         {
-            _handlerMock.VerifyWithTimeout(x => x(It.IsAny<TEvent>()), Times.Never(), _verificationTimeout);
+            if (_handlersMap.Count == 0)
+                return;
+
+            foreach (var eventType in _handlersMap.Keys)
+            {
+                var verifyMethod = GetGenericMethod(
+                    nameof(VerifyMessageReceived),
+                    new[] { eventType });
+
+                await (Task)verifyMethod.Invoke(
+                    this,
+                    new object[] { ItIsAnyObjectPredicate(eventType), Times.Never() });
+            }
+        }
+
+        private LambdaExpression ItIsAnyObjectPredicate(Type eventType)
+        {
+            var parameter = Expression.Parameter(eventType, "x");
+            var body = Expression.Constant(true);
+            var selector = Expression.Lambda(body, parameter);
+            return selector;
+        }
+
+        private MethodInfo GetGenericMethod(string name, Type[] genericArguments)
+        {
+            var method = typeof(TestHubConnection)
+                .GetMethods()
+                .First(m => m.ContainsGenericParameters && m.Name == name)
+                .MakeGenericMethod(genericArguments);
+
+            return method;
+        }
+
+        private void RegisterHandler<TEvent>(Mock<Action<TEvent>> handler)
+        {
+            if (!_handlersMap.TryGetValue(typeof(TEvent), out object handlersForType))
+            {
+                handlersForType = new List<Mock<Action<TEvent>>>();
+                _handlersMap[typeof(TEvent)] = handlersForType;
+            }
+
+            var handlers = (List<Mock<Action<TEvent>>>)handlersForType;
+            handlers.Add(handler);
         }
     }
 }


### PR DESCRIPTION
…one connection for many events.